### PR TITLE
Cookies null error fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,14 @@ async function main(currentBookedDate) {
 async function login() {
   log(`Logging in`)
 
-  const anonymousHeaders = await fetch(`${BASE_URI}/users/sign_in`)
+  const anonymousHeaders = await fetch(`${BASE_URI}/users/sign_in`, {
+    headers: {
+      "User-Agent": "",
+      "Accept": "*/*",
+      "Accept-Encoding": "gzip, deflate, br",
+      "Connection": "keep-alive",
+    },
+  })
     .then(response => extractHeaders(response))
 
   return fetch(`${BASE_URI}/users/sign_in`, {


### PR DESCRIPTION
After the recent minor changes to the website, it now expects the added headers to be sent along with the initial sign in request to get the token. If they are not received, it throws back a 403 error, resulting in the initial login cookies to be null, thus leading to a failed date check.

I have added the necessary headers in this PR.